### PR TITLE
Defsault panel for unknown metrics, short flags, handle empty selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-08-12
+### Added
+ - Short flags for most common flags, see `--help` or [readme](https://github.com/FUSAKLA/autograf#how-to-use)
+### Fixed
+ - Correctly handle metric selectors if no `--selector` is set
+### Changed
+ - Metric with unknown type is now visualized as gauge in time series panel as "best effort"
+
 ## [1.0.1] - 2022-07-12
  - Fixed default folder name
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Example from Prometheus query:
 Flags:
   -h, --help                                       Show context-sensitive help.
       --debug                                      Enable debug logging
-      --metrics-file=STRING                        File containing the metrics exposed by app (will read stdin if se to - )
+  -f, --metrics-file=STRING                        File containing the metrics exposed by app (will read stdin if se to - )
       --open-metrics-format                        Metrics data are in the application/openmetrics-text format.
-      --prometheus-url=STRING                      URL of Prometheus instance to fetch the metrics from.
-      --selector=STRING                            Selector to filter metrics from the Prometheus instance.
+  -p, --prometheus-url=STRING                      URL of Prometheus instance to fetch the metrics from.
+  -s, --selector=STRING                            Selector to filter metrics from the Prometheus instance.
       --grafana-variables=GRAFANA-VARIABLES,...    Labels used as a variables for filtering in dashboard
       --grafana-url=STRING                         URL of Grafana to upload the dashboard to, if not specified, dashboard JSON is printed to stdout
       --grafana-folder=STRING                      Name of target Grafana folder

--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -33,7 +32,7 @@ func loadConfig(logger logrus.FieldLogger) config {
 		}
 		configFilePath = path.Join(home, ".autograf.json")
 	}
-	data, err := ioutil.ReadFile(configFilePath)
+	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return c
 	}

--- a/generate.go
+++ b/generate.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"runtime"
 	"time"
@@ -29,7 +29,7 @@ func openInBrowser(url string) error {
 func (r *Command) Run(ctx *Context) error {
 	var metrics map[string]prometheus.Metric
 	if r.MetricsFile != "" {
-		data, err := ioutil.ReadFile(r.MetricsFile)
+		data, err := os.ReadFile(r.MetricsFile)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -39,11 +39,11 @@ Example from Prometheus query:
 type Command struct {
 	Debug bool `help:"Enable debug logging"`
 
-	MetricsFile       string `help:"File containing the metrics exposed by app (will read stdin if se to - )"`
+	MetricsFile       string `short:"f" help:"File containing the metrics exposed by app (will read stdin if se to - )"`
 	OpenMetricsFormat bool   `help:"Metrics data are in the application/openmetrics-text format."`
 
-	PrometheusURL    string   `help:"URL of Prometheus instance to fetch the metrics from."`
-	Selector         string   `help:"Selector to filter metrics from the Prometheus instance."`
+	PrometheusURL    string   `short:"p" help:"URL of Prometheus instance to fetch the metrics from."`
+	Selector         string   `short:"s" help:"Selector to filter metrics from the Prometheus instance."`
 	GrafanaVariables []string `help:"Labels used as a variables for filtering in dashboard"`
 
 	GrafanaURL           string `help:"URL of Grafana to upload the dashboard to, if not specified, dashboard JSON is printed to stdout"`

--- a/packages/generator/dashboard.go
+++ b/packages/generator/dashboard.go
@@ -25,14 +25,21 @@ func newRow(dataSource string, selector string, name string, metrics []*promethe
 }
 
 func selectorWithVariablesFilter(selector string, filerVariables []string) string {
-	new := strings.TrimSuffix(selector, "}")
-	for _, v := range filerVariables {
-		new += fmt.Sprintf(",%s=~'$%s'", v, v)
+	new := strings.TrimSuffix(selector, "}") + ","
+	if selector == "" {
+		new = "{"
 	}
-	return new + "}"
+	filters := make([]string, len(filerVariables))
+	for i, v := range filerVariables {
+		filters[i] = fmt.Sprintf("%s=~'$%s'", v, v)
+	}
+	return new + strings.Join(filters, ",") + "}"
 }
 
 func labelVariable(datasourceName, selector, name string) dashboard.Option {
+	if selector == "" {
+		selector = "up"
+	}
 	return dashboard.VariableAsQuery(
 		name,
 		query.DataSource(datasourceName),

--- a/packages/generator/panel.go
+++ b/packages/generator/panel.go
@@ -73,6 +73,6 @@ func newPanel(dataSource string, selector string, metric prometheus.Metric) row.
 	case "info":
 		return newInfoPanel(dataSource, selector, metric)
 	}
-	metric.Comment = fmt.Sprintf("WARNING: Unknown metric type %s!\n%s", metric.MetricType, metric.Comment)
+	metric.Help = fmt.Sprintf("WARNING: Unknown metric type %s!\n\n%s", metric.MetricType, metric.Help)
 	return newTimeSeriesPanel(dataSource, selector, metric)
 }

--- a/packages/generator/panel.go
+++ b/packages/generator/panel.go
@@ -7,7 +7,6 @@ import (
 	"github.com/K-Phoen/grabana/row"
 	"github.com/K-Phoen/grabana/table"
 	grabana_prometheus "github.com/K-Phoen/grabana/target/prometheus"
-	"github.com/K-Phoen/grabana/text"
 	"github.com/K-Phoen/grabana/timeseries"
 	"github.com/K-Phoen/grabana/timeseries/axis"
 	"github.com/fusakla/autograf/packages/prometheus"
@@ -74,5 +73,6 @@ func newPanel(dataSource string, selector string, metric prometheus.Metric) row.
 	case "info":
 		return newInfoPanel(dataSource, selector, metric)
 	}
-	return row.WithText("", text.HTML(fmt.Sprintf("unknown type %s of metric %s", metric.MetricType, metric.Name)))
+	metric.Comment = fmt.Sprintf("WARNING: Unknown metric type %s!\n%s", metric.MetricType, metric.Comment)
+	return newTimeSeriesPanel(dataSource, selector, metric)
 }


### PR DESCRIPTION
Few fixes and features based on the https://github.com/FUSAKLA/autograf/issues/2

- If metric type is unknown, time series panel is now used instead text panel with warning 
- added support for short flags
- fix metric selectors in queries if the `--selector` is not set